### PR TITLE
Fix README license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![GCC](https://img.shields.io/badge/GCC-10.5-green)](https://github.com/Scottcjn/ppc-compilers) [![PowerPC](https://img.shields.io/badge/PowerPC-G4%2FG5-orange)](https://github.com/Scottcjn/ppc-compilers)
+[![License](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE) [![GCC](https://img.shields.io/badge/GCC-10.5-green)](https://github.com/Scottcjn/ppc-compilers) [![PowerPC](https://img.shields.io/badge/PowerPC-G4%2FG5-orange)](https://github.com/Scottcjn/ppc-compilers)
 [![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-brightgreen?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAxTDMgNXY2YzAgNS41NSAzLjg0IDEwLjc0IDkgMTIgNS4xNi0xLjI2IDktNi40NSA5LTEyVjVsLTktNHptLTIgMTZsLTQtNCA1LjQxLTUuNDEgMS40MSAxLjQxTDEwIDE0bDYtNiAxLjQxIDEuNDFMMTAgMTd6Ii8+PC9zdmc+)](BCOS.md)
 
 # Modern Compilers for PowerPC Mac OS X Tiger & Leopard


### PR DESCRIPTION
## Summary
- update the README license badge from Apache 2.0 to AGPL v3
- link the badge to the repository LICENSE file, matching the existing License section

## Validation
- `git diff --check HEAD~1..HEAD`
- `rg -n "License-Apache_2\.0|Apache-2\.0|License-AGPL_v3|AGPL v3" README.md LICENSE`

Bounty: Scottcjn/rustchain-bounties#2178